### PR TITLE
Abstract is really narrow on papers and events

### DIFF
--- a/modules/blox/layouts/events/page.html
+++ b/modules/blox/layouts/events/page.html
@@ -226,7 +226,7 @@
 
       {{/* EVENT METADATA */}}
       {{ if .Params.abstract | or (eq .Type "events") }}
-        <div class="max-w-prose grid grid-cols-1 md:grid-cols-[200px_auto] gap-4 my-6">
+        <div class="max-w-2xl grid grid-cols-1 md:grid-cols-[200px_auto] gap-4 my-6">
 
         {{ if .Params.abstract }}
           <div class="font-bold text-2xl">{{ i18n "abstract" }}</div>

--- a/modules/blox/layouts/single.html
+++ b/modules/blox/layouts/single.html
@@ -232,7 +232,7 @@
 
       {{/* EVENT / PUBLICATION METADATA */}}
       {{ if .Params.abstract | or (eq .Type "publications") | or (eq .Type "events") }}
-        <div class="max-w-prose grid grid-cols-1 md:grid-cols-[200px_auto] gap-4 my-6">
+        <div class="max-w-2xl grid grid-cols-1 md:grid-cols-[200px_auto] gap-4 my-6">
 
         {{ if .Params.abstract }}
           <div class="font-bold text-2xl">{{ i18n "abstract" }}</div>


### PR DESCRIPTION
I found the abstract was really narrow on papers and events, and looks better to my eye when the metadata grid has `max-w-2xl` rather than `max-w-prose`. Feel free to close if you disagree.

### 🚀 What type of change is this?

- [ ] 🐛 **Bug fix** (A non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (A non-breaking change that adds functionality)
- [x] 💅 **Style change** (A change that only affects formatting, visuals, or styling)
- [ ] 📚 **Documentation update** (Changes to documentation only)
- [ ] 🧹 **Refactor or chore** (A code change that neither fixes a bug nor adds a feature)
- [ ] 💥 **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)

---

### 🎯 What is the purpose of this change?
To make the abstract more legible
---

### 📸 Screenshots or Screencast (if applicable)
Before (max-w-prose):
<img width="2755" height="1405" alt="image" src="https://github.com/user-attachments/assets/87907f30-16e6-4e58-9ac0-534bf1b94ce6" />

After (max-w-2xl):
<img width="2779" height="1748" alt="image" src="https://github.com/user-attachments/assets/1d91813b-3cab-488a-b553-5a29601330f1" />


---

### ℹ️ Documentation Check

- [x] No, this change does not require a documentation update.
- [ ] Yes, I have updated the documentation accordingly (or will in a follow-up PR).

---

### 📜 Contributor Agreement

**Thank you for your contribution!**

- [x] By checking this box, I confirm that I have read and agree to the [HugoBlox Contributor License Agreement (CLA)](/.github/CLA.md).
